### PR TITLE
Ensure that only visible notes are copied

### DIFF
--- a/note_copy.py
+++ b/note_copy.py
@@ -197,13 +197,14 @@ class DanbooruPost(BooruPost):
         api_notes = r.json()
 
         for note in api_notes:
-            notes.append(Note(
-                note['x'],
-                note['y'],
-                note['width'],
-                note['height'],
-                note['body'],
-            ))
+            if note['is_active']:
+                notes.append(Note(
+                    note['x'],
+                    note['y'],
+                    note['width'],
+                    note['height'],
+                    note['body'],
+                ))
 
         return notes
 


### PR DESCRIPTION
When notes have been copied from one Danbooru post to another using the
built-in site feature, Danbooru will add an additional, inactive note.
This note should not be copied anywhere else. For full details, see:
https://github.com/r888888888/danbooru/blob/6ad774b/app/models/post.rb#L1461